### PR TITLE
Fix for the issue when  "destructive" parameter is null

### DIFF
--- a/Controls.UserDialogs.Maui/Platforms/iOS/Builders/ActionSheetBuilder.cs
+++ b/Controls.UserDialogs.Maui/Platforms/iOS/Builders/ActionSheetBuilder.cs
@@ -28,7 +28,11 @@ public class ActionSheetBuilder
 
         Config.Options.ToList().ForEach(o => alert.AddAction(GetOptionAction(o)));
 
-        alert.AddAction(GetDestructiveAction());
+        if (Config.Destructive is not null)
+        {
+            alert.AddAction(GetDestructiveAction());
+        }
+
         alert.AddAction(GetCancelAction());
 
         if (Config.Title is not null)


### PR DESCRIPTION
To reproduce this issue (crash) use
`var menuSelection = await UserDialogs.Instance.ActionSheetAsync("", title: null, cancel: "cancel",  null, buttons: "selection");`

As a workaround we can put `string.Empty` as a "destructive" parameter but in this case, we will have additional empty menu.
This fix aligns behavior with UserDialogs for Xamarin.Forms