### PR TITLE
removing null coalescing since these properties are never null via de…

### DIFF
--- a/Controls.UserDialogs.Maui/Platforms/MacCatalyst/UserDialogsImplementation.cs
+++ b/Controls.UserDialogs.Maui/Platforms/MacCatalyst/UserDialogsImplementation.cs
@@ -40,8 +40,8 @@ public partial class UserDialogsImplementation
                 FontFamily = config.MessageFontFamily,
                 Position = config.Position.ToNative(),
             };
-            bar.BackgroundColor ??= config.BackgroundColor.ToPlatform();
-            bar.MessageColor ??= config.MessageColor.ToPlatform();
+            bar.BackgroundColor = config.BackgroundColor?.ToPlatform() ?? bar.BackgroundColor;
+            bar.MessageColor = config.MessageColor?.ToPlatform() ?? bar.MessageColor;
             bar.Show();
         });
 

--- a/Controls.UserDialogs.Maui/Platforms/iOS/UserDialogsImplementation.cs
+++ b/Controls.UserDialogs.Maui/Platforms/iOS/UserDialogsImplementation.cs
@@ -40,8 +40,8 @@ public partial class UserDialogsImplementation
                 FontFamily = config.MessageFontFamily,
                 Position = config.Position.ToNative(),
             };
-            bar.BackgroundColor = config.BackgroundColor.ToPlatform();
-            bar.MessageColor = config.MessageColor.ToPlatform();
+            bar.BackgroundColor = config.BackgroundColor?.ToPlatform() ?? bar.BackgroundColor;
+            bar.MessageColor = config.MessageColor?.ToPlatform() ?? bar.MessageColor;
             bar.Show();
         });
 

--- a/Controls.UserDialogs.Maui/Platforms/iOS/UserDialogsImplementation.cs
+++ b/Controls.UserDialogs.Maui/Platforms/iOS/UserDialogsImplementation.cs
@@ -40,8 +40,8 @@ public partial class UserDialogsImplementation
                 FontFamily = config.MessageFontFamily,
                 Position = config.Position.ToNative(),
             };
-            bar.BackgroundColor ??= config.BackgroundColor.ToPlatform();
-            bar.MessageColor ??= config.MessageColor.ToPlatform();
+            bar.BackgroundColor = config.BackgroundColor.ToPlatform();
+            bar.MessageColor = config.MessageColor.ToPlatform();
             bar.Show();
         });
 


### PR DESCRIPTION
was having an issue where toast colors weren't changing on iOS but they were on Android. looks like the background color and message color have default values now so they'll never be null so the null coalescing prevents the values from being updated