### PR TITLE
Fix UI is not blocking controls #16

### DIFF
--- a/Controls.UserDialogs.Maui/Platforms/Android/HudDialog.cs
+++ b/Controls.UserDialogs.Maui/Platforms/Android/HudDialog.cs
@@ -131,8 +131,6 @@ public class HudDialog : IHudDialog
             typeFace = Typeface.CreateFromAsset(Activity.Assets, _config.MessageFontFamily);
         }
 
-        dialog.Window.AddFlags(WindowManagerFlags.NotFocusable);
-
         var textViewId = Activity.Resources.GetIdentifier("textViewStatus", "id", Activity.PackageName);
         var textView = dialog.FindViewById<TextView>(textViewId);
 


### PR DESCRIPTION
The code `dialog.Window.AddFlags(WindowManagerFlags.NotFocusable);`  It was causing AndHUD to not lock the other controls as a modal.