### PR TITLE
Update to dotnet 9

### DIFF
--- a/Controls.UserDialogs.Maui/Controls.UserDialogs.Maui.csproj
+++ b/Controls.UserDialogs.Maui/Controls.UserDialogs.Maui.csproj
@@ -1,16 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net9.0-android35.0;net9.0-ios18.4;net9.0-maccatalyst18.4</TargetFrameworks>
+		<TargetFrameworks>net8.0;net8.0-android34.0;net8.0-ios18.0;net8.0-maccatalyst18.0;net9.0;net9.0-android35.0;net9.0-ios18.4;net9.0-maccatalyst18.4</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<MauiVersion>9.0.60</MauiVersion>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework) == 'net8.0-ios18.0'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework) == 'net9.0-ios18.4'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework) == 'net8.0-maccatalyst18.0'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework) == 'net9.0-maccatalyst18.4'">15.0</SupportedOSPlatformVersion>
 
 		<DefineConstants Condition="$(TargetFramework.Contains('ios')) OR $(TargetFramework.Contains('maccatalyst'))">$(DefineConstants);MACIOS</DefineConstants>
 		

--- a/Controls.UserDialogs.Maui/Controls.UserDialogs.Maui.csproj
+++ b/Controls.UserDialogs.Maui/Controls.UserDialogs.Maui.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net8.0-android34.0;net8.0-ios17.0;net8.0-maccatalyst17.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net9.0-android35.0;net9.0-ios18.4;net9.0-maccatalyst18.4</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<MauiVersion>8.0.3</MauiVersion>
+		<MauiVersion>9.0.60</MauiVersion>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 
 		<DefineConstants Condition="$(TargetFramework.Contains('ios')) OR $(TargetFramework.Contains('maccatalyst'))">$(DefineConstants);MACIOS</DefineConstants>
 		
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>Controls.UserDialogs.Maui</Title>
-		<Version>1.7.0</Version>
+		<Version>1.8.0</Version>
 		<Authors>Alex Dobrynin</Authors>
 		<Description>This is the updated version of Acr.Userdialogs. It supports latest version of .Net and you have an ability to style your dialogs as you want</Description>
 		<Copyright>Alex Dobrynin</Copyright>
@@ -52,10 +52,10 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.Contains('android'))">
-	  <PackageReference Include="AndHUD" Version="2.0.1" />
+	  <PackageReference Include="AndHUD" Version="2.1.0" />
 	</ItemGroup>
 	<ItemGroup Condition="$(TargetFramework.Contains('ios')) OR $(TargetFramework.Contains('maccatalyst')) ">
-	  <PackageReference Include="BTProgressHUD" Version="2.0.1" />
+	  <PackageReference Include="BTProgressHUD" Version="2.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Controls.UserDialogs.Maui/MaciOS/HudDialog.cs
+++ b/Controls.UserDialogs.Maui/MaciOS/HudDialog.cs
@@ -126,7 +126,7 @@ public class HudDialog : IHudDialog
     {
         if (_config.MessageColor is not null)
         {
-            hud.HudForegroundColor = _config.MessageColor.ToPlatform();
+            ProgressHUDAppearance.HudTextColor = _config.MessageColor.ToPlatform();
         }
 
         UIFont? font = null;
@@ -136,7 +136,7 @@ public class HudDialog : IHudDialog
         }
         font ??= UIFont.SystemFontOfSize((float)_config.MessageFontSize);
 
-        hud.HudFont = font;
+        ProgressHUDAppearance.HudFont = font;
     }
 
     private void AfterShowImage(ProgressHUD hud)
@@ -173,10 +173,10 @@ public class HudDialog : IHudDialog
     {
         if (_config.MessageColor is not null)
         {
-            hud.HudForegroundColor = _config.MessageColor.ToPlatform();
+            ProgressHUDAppearance.HudTextColor = _config.MessageColor.ToPlatform();
         }
-        hud.RingThickness = 4f;
-        hud.RingRadius = 22f;
+        ProgressHUDAppearance.RingThickness = 4f;
+        ProgressHUDAppearance.RingRadius = 22f;
 
         if (hud.Subviews.FirstOrDefault() is UIToolbar toolbar && _config.ProgressColor is not null)
         {
@@ -198,7 +198,7 @@ public class HudDialog : IHudDialog
         }
         font ??= UIFont.SystemFontOfSize((float)_config.MessageFontSize);
 
-        hud.HudFont = font;
+        ProgressHUDAppearance.HudFont = font;
     }
 
     private void AfterShow(ProgressHUD hud)

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -5,7 +5,6 @@
 		<OutputType>Exe</OutputType>
 		<RootNamespace>Sample</RootNamespace>
 		<UseMaui>true</UseMaui>
-		<MauiVersion>9.0.60</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 
@@ -22,7 +21,7 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 
 		<MtouchLink>SdkOnly</MtouchLink>
 		<MtouchExtraArgs>$(MtouchExtraArgs) --weak-framework=NewsstandKit</MtouchExtraArgs>

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>Sample</RootNamespace>
 		<UseMaui>true</UseMaui>
+		<MauiVersion>9.0.60</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 
@@ -19,7 +20,7 @@
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
 

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,10 @@ Inspired by [Allan Ritchie](https://github.com/aritchie)'s Acr.UserDialogs
 
 ## Supported Platforms
 
+* .NET8
+* .NET8 for Android (min 7.0)(major target 14.0)
+* .NET8 for iOS (min 14.2)
+* .NET8 for MacCatalyst (min 14.2)
 * .NET9
 * .NET9 for Android (min 7.0)(major target 14.0)
 * .NET9 for iOS (min 15.0)

--- a/readme.md
+++ b/readme.md
@@ -12,10 +12,10 @@ Inspired by [Allan Ritchie](https://github.com/aritchie)'s Acr.UserDialogs
 
 ## Supported Platforms
 
-* .NET8
-* .NET8 for Android (min 7.0)(major target 14.0)
-* .NET8 for iOS (min 14.2)
-* .NET8 for MacCatalyst (min 13.1)
+* .NET9
+* .NET9 for Android (min 7.0)(major target 14.0)
+* .NET9 for iOS (min 15.0)
+* .NET9 for MacCatalyst (min 15.0)
 
 ### Features
 


### PR DESCRIPTION
Updates the library to dotnet 9 and MAUI 9.0.60.

Updates the AndHUD and BTProgressHUD to latest versions on NuGet.

Some changes in the BTProgressHUB API around styling, which is now done on a static `ProgressHUDAppearance` class, as described here: https://github.com/redth-org/BTProgressHUD?tab=readme-ov-file#customization

Bumps the version from v1.7.0 to v1.8.0.

Would be fantastic if you could review the PR and publish a new NuGet package @Alex-Dobrynin 🙏.