### PR TITLE
Check if PopoverPresentationController is null

### DIFF
--- a/Controls.UserDialogs.Maui/MaciOS/UserDialogsImplementation.cs
+++ b/Controls.UserDialogs.Maui/MaciOS/UserDialogsImplementation.cs
@@ -108,19 +108,26 @@ public partial class UserDialogsImplementation
         app.SafeInvokeOnMainThread(() =>
         {
             alert = alertFunc();
-            var top = Platform.GetCurrentUIViewController()!;
-            if (alert.PreferredStyle == UIAlertControllerStyle.ActionSheet && UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+            var top = Platform.GetCurrentUIViewController();
+            if (alert.PreferredStyle == UIAlertControllerStyle.ActionSheet && 
+                UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad &&
+                top != null)
             {
                 var x = top.View!.Bounds.Width / 2;
                 var y = top.View.Bounds.Bottom;
                 var rect = new CGRect(x, y, 0, 0);
 #if __IOS__
-                alert.PopoverPresentationController!.SourceView = top.View;
-                alert.PopoverPresentationController.SourceRect = rect;
-                alert.PopoverPresentationController.PermittedArrowDirections = UIPopoverArrowDirection.Unknown;
+                // We need to check if the popover presentation controller is not null
+                // in case the iPadOS application is executing on a macOS device.
+                if (alert.PopoverPresentationController != null)
+                {
+                    alert.PopoverPresentationController.SourceView = top.View;
+                    alert.PopoverPresentationController.SourceRect = rect;
+                    alert.PopoverPresentationController.PermittedArrowDirections = UIPopoverArrowDirection.Unknown;
+                }
 #endif
             }
-            top.PresentViewController(alert, true, null);
+            top?.PresentViewController(alert, true, null);
         });
         return new DisposableAction(() => app.SafeInvokeOnMainThread(() => alert?.DismissViewController(true, null)));
     }


### PR DESCRIPTION
The Action Sheets are not working when the library is used in an iPadOS application that is executing on macOS (I am not talking about the Catalyst version). This is a known problem that also the Action Sheet implementation in MAUI had: https://github.com/dotnet/maui/pull/19629.

If you look at the PR, the fix involves checking wether the `PopoverPresentationController` is null. Looking at the [Apple documentation](https://developer.apple.com/documentation/uikit/uiviewcontroller/popoverpresentationcontroller) it says:

> If the view controller or one of its ancestors is managed by a popover presentation controller, this property contains that object. This property is nil if the view controller is not managed by a popover presentation controller.

So there are situations where this can be nil.

I think this is a safe fix that couldn't break anything but hopefully fix the problem I am facing. Testing the fix is a bit involved, as I need to build the NuGet package, and publish the app to TestFlight as you cannot build and run iPadOS applications directly on macOS, but have to publish them to TestFlight and then install it on your local computer for testing.

So if you agree that the changes are safe (only null checking), it would be great if they could be included in the v1.8.0 NuGet package.